### PR TITLE
fixed inference bug

### DIFF
--- a/src/inference.py
+++ b/src/inference.py
@@ -188,7 +188,8 @@ class TransformersService(InferenceService):
                 trust_remote_code=True,
                 dtype=torch.bfloat16,
                 device_map="auto",
-                attn_implementation="eager"
+                attn_implementation="eager",
+                stop=["<|end_of_text|>", "<eos>", "<end_of_turn>"] # need to be overridden for other models
             )
         
         # Set pad token if it doesn't exist
@@ -307,12 +308,9 @@ async def run_generation(
     num_generations: int,
     sampling: str,
     max_retries: int = 10,
-    stop_sequences: list[str] | None = None,
 ) -> list[str]:
     responses = []
     messages = [{"role": "user", "content": prompt}]
-    if stop_sequences is None:
-        stop_sequences = ["<|end_of_text|>", "<eos>", "<end_of_turn>"] # These may need to be adjusted depending on the model
     for attempt in range(max_retries):
         try:
             if sampling == "regenerate":
@@ -323,7 +321,6 @@ async def run_generation(
                     max_tokens=512,
                     temperature=1.0,
                     n=num_generations,
-                    stop=stop_sequences,
                 )
 
             elif sampling == "in-context":
@@ -333,7 +330,6 @@ async def run_generation(
                         messages=messages,
                         max_tokens=512,
                         temperature=1.0,
-                        stop=stop_sequences,
                     )
                     new_response = response[0]
                     responses.append(new_response)
@@ -356,7 +352,6 @@ async def run_generation(
                         messages=messages,
                         max_tokens=512,
                         temperature=1.0,
-                        stop=stop_sequences,
                     )
                     new_response = response[0]
                     responses.append(new_response)
@@ -375,7 +370,6 @@ async def run_generation(
                     max_tokens=512,
                     temperature=1.0,
                     n=num_generations,
-                    stop=stop_sequences,
                 )
             else:
                 raise Exception("Unknown mode " + sampling)
@@ -421,7 +415,6 @@ async def process_prompts(
                     prompt.get("prompt_paraphrases"),
                     num_generations,
                     sampling,
-                    stop_sequences,
                 )
                 return {
                     "id": prompt["id"],


### PR DESCRIPTION
apparently my edit to the last PR w/ stop_sequences on transformers actually broke for now - added to the old functionality for now. Users need to override stop_tokens for new models potentially, but the only other way around that would be to add stop sequences as an argument to every other service which would be cumbersome.

I think this could be useful still, as this way users can do inference w/out VLLM if desired. But if the hardcoded stop_sequences isn't desired,  I'll instead opt to just remove the `TransformersService` functionality.