### PR TITLE
README: document the classifier's 128-token effective input window

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ uv sync
    python src/summarize.py --eval-dir results/curated/gpt4o
    ```
 
+### Note on classifier input length
+
+**Caution:** the `classifier` equivalence algorithm truncates **each response to
+its first 128 tokens** before scoring (`max_length=128` in `src/partition.py`).
+The same truncation was applied when the classifier was fine-tuned (`MAX_LEN` in
+`src/classifier/finetune_classifier.py`), so this is the model's effective
+comparison window rather than an inference-time mismatch — but it does mean that
+any content past that window has no effect on the partition. Two responses that
+share an opening and diverge only later will be scored as if they were identical.
+
+This is worth checking before applying the classifier to long-form generations.
+For reference, the released classifier training data (`data/train.jsonl`) has a
+median response length of roughly 308 whitespace-delimited words, already well
+beyond the 128-token window the model actually sees, so the window is a ceiling
+on the comparison rather than a limit that long inputs merely approach. If your
+responses carry their distinguishing content late — later turns, rebuttals,
+conclusions — the partition may under-count distinct responses, and results are
+best interpreted as a judgement about the opening of each response.
+
 ### Full Worked Example
 
 For example, to run gemma-3-1b-it from start to finish:


### PR DESCRIPTION
## Summary

Adds a short caution to the README documenting that the `classifier` equivalence algorithm only ever sees the first 128 tokens of each response.

Raised by a downstream user fine-tuning on the released classifier: their median response is ~488 tokens, so the partition was being decided on roughly a quarter of each text, and nothing in the README, paper, or model card says so.

## What I verified in the code

- `src/partition.py:69` — `classifier_score` encodes each of the two responses with `truncation=True, max_length=128`, so each response contributes at most 128 tokens.
- `src/classifier/finetune_classifier.py:35` — `MAX_LEN = 128`, applied at `:114` and `:139`.

The second point is the nuance worth keeping: train and inference truncate identically, so this is **not** a train/inference mismatch or a bug in the released path. It is the model's genuine effective window. The README wording says this explicitly so the note doesn't read as a defect report.

For reference, `data/train.jsonl` has a median response length of ~308 whitespace-delimited words (mean 264, max 465), which is already well past a 128-token window under any tokenizer — so the window is a ceiling on the comparison rather than a limit that only unusually long inputs reach.

## What this does not do

- No behavior change. `partition.py` and the classifier are untouched, so existing partitions and leaderboard numbers are unaffected.
- Does not add a runtime warning when input exceeds the window. That was also suggested, but it changes the behavior of an already-released artifact and seemed like a maintainer call rather than something to fold into a docs PR. Happy to add it as a follow-up if you want it.
- I could not verify token-level length statistics directly — Hugging Face is not reachable from this sandbox, so `microsoft/deberta-v3-large`'s tokenizer could not be loaded. The figures quoted are whitespace word counts, and the README labels them as such.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Woit9hWCUHbW8krGARZkiU)_